### PR TITLE
implementing message dumping to file

### DIFF
--- a/concon/games/aliceBob.py
+++ b/concon/games/aliceBob.py
@@ -121,7 +121,7 @@ class AliceBob(Game):
     # batch: Batch
     def compute_interaction(self, batch, **kwargs):
         # TODO: change return signature to loss, {dict of things to log}
-        
+
         sender_outcome, receiver_outcome = self(batch)
 
         # Alice's part
@@ -304,12 +304,12 @@ class AliceBob(Game):
             import csv
             with open(self.message_dump_file + f'.e{epoch_index}.csv', 'w') as ostr:
                 writer = csv.writer(ostr)
-                _ = writer.writerow('msg', 'cat', 'idx')
+                _ = writer.writerow(['msg', 'cat', 'idx'])
                 for msg, cat, idx in zip(messages, categories, input_ids):
                     msg = ' '.join(map(str, msg))
                     row = [msg, cat, idx]
                     _ = writer.writerow(row)
-        
+
 
         success_prob = torch.stack(success_prob)
         scrambled_success_prob = torch.stack(scrambled_success_prob)

--- a/concon/games/aliceBob.py
+++ b/concon/games/aliceBob.py
@@ -265,7 +265,7 @@ class AliceBob(Game):
         for batch_index in batch_numbers:
             self.start_episode(train_episode=False)
 
-            batch = data_iterator.get_batch(batch_size, data_type='test', no_evaluation=False, sampling_strategies=['different'], keep_category=True) # We use all categories and use only one distractor from a different category. The target image is selected in the same way as it is selected during training (equal to the original image vs a different one).
+            batch = data_iterator.get_batch(batch_size, data_type='test', no_evaluation=False, sampling_strategies=['different'], keep_category=True, keep_idx=True) # We use all categories and use only one distractor from a different category. The target image is selected in the same way as it is selected during training (equal to the original image vs a different one).
 
             sender_outcome, receiver_outcome = self.alice_to_bob(batch)
 
@@ -307,6 +307,7 @@ class AliceBob(Game):
                 _ = writer.writerow(['msg', 'cat', 'idx'])
                 for msg, cat, idx in zip(messages, categories, input_ids):
                     msg = ' '.join(map(str, msg))
+                    cat = ' '.join(map(str, cat))
                     row = [msg, cat, idx]
                     _ = writer.writerow(row)
 

--- a/concon/games/aliceBobCharlie.py
+++ b/concon/games/aliceBobCharlie.py
@@ -67,6 +67,7 @@ class AliceBobCharlie(AliceBob):
         self.log_charlie_sample_imgs = not (args.no_summary or args.no_log_imgs)
         self.log_img_every = args.log_img_every
         self._batch_for_img_gen = None
+        self.message_dump_file = args.message_dump_file
 
     @property
     def drawer(self):

--- a/concon/utils/opts.py
+++ b/concon/utils/opts.py
@@ -119,9 +119,11 @@ def get_args():
     group.add_argument('--load_model', help='the path to the model to load', type=pathlib.Path)
     # For evaluate_language.py
     group.add_argument('--load_other_model', help='path to a second model to load', type=pathlib.Path)
-    group.add_argument('--message_dump_file', help='file containing language sample, or file where to dump language sample.')
     group.add_argument('--string_msgs', action='store_true', help='specifies whether provided messages should be considered as strings rather than sequences of symbols (integers).')
     group.add_argument('--debug', '-d', help='use this flag to change the behavior of the code to debug stuff', action='store_true')
+
+    group.add_argument('--message_dump_file', help='file containing language sample, or file where to dump language sample.')
+
 
     args = arg_parser.parse_args()
     if not args.quiet:


### PR DESCRIPTION
Uses the existing flag `message_dump_file` to generate CSVs containing message, category and input image index for each evaluation epoch.